### PR TITLE
Update Application.mk

### DIFF
--- a/android/jni/Application.mk
+++ b/android/jni/Application.mk
@@ -1,2 +1,2 @@
-APP_ABI := armeabi-v7a
-# APP_STL := gnustl_static
+APP_ABI := armeabi-v7a arm64-v8a
+APP_PLATFORM := android-21


### PR DESCRIPTION
Addition flag to build 64 bits version of the library for Android.
Changed the minimal target to android 21 (min for 64 bits)